### PR TITLE
cause exception information should be able to be added to logging message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/masonite_logging.*
 src/monolog.*
 .python-version
 .idea
+storage/logs/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ venv
 dist
 src/masonite_logging.*
 src/monolog.*
+.python-version
+.idea

--- a/src/masonite/logging/drivers/LogSingleDriver.py
+++ b/src/masonite/logging/drivers/LogSingleDriver.py
@@ -31,54 +31,54 @@ class LogSingleDriver(BaseDriver):
         self.change_format('{} - {} - %(message)s'.format(
                 self.get_time().to_datetime_string(),
                 'EMERGENCY'))
-        return self.log.critical(message)
+        return self.log.critical(message, *args, **kwargs)
 
     def alert(self, message, *args, **kwargs):
         self.log.setLevel(logging.CRITICAL)
         self.change_format('{} - {} - %(message)s'.format(
                 self.get_time().to_datetime_string(),
                 'ALERT'))
-        return self.log.critical(message)
+        return self.log.critical(message, *args, **kwargs)
 
     def critical(self, message, *args, **kwargs):
         self.log.setLevel(logging.CRITICAL)
         self.change_format('{} - {} - %(message)s'.format(
             self.get_time().to_datetime_string(),
             'CRITICAL'))
-        return self.log.critical(message)
+        return self.log.critical(message, *args, **kwargs)
 
     def error(self, message, *args, **kwargs):
         self.log.setLevel(logging.ERROR)
         self.change_format('{} - {} - %(message)s'.format(
             self.get_time().to_datetime_string(),
             'ERROR'))
-        return self.log.error(message)
+        return self.log.error(message, *args, **kwargs)
 
     def warning(self, message, *args, **kwargs):
         self.log.setLevel(logging.WARNING)
         self.change_format('{} - {} - %(message)s'.format(
             self.get_time().to_datetime_string(),
             'WARNING'))
-        return self.log.warning(message)
+        return self.log.warning(message, *args, **kwargs)
 
     def notice(self, message, *args, **kwargs):
         self.log.setLevel(logging.INFO)
         self.change_format('{} - {} - %(message)s'.format(
             self.get_time().to_datetime_string(),
             'NOTICE'))
-        return self.log.info(message)
+        return self.log.info(message, *args, **kwargs)
 
     def info(self, message, *args, **kwargs):
         self.log.setLevel(logging.INFO)
         self.change_format('{} - {} - %(message)s'.format(
             self.get_time().to_datetime_string(),
             'INFO'))
-        return self.log.info(message)
+        return self.log.info(message, *args, **kwargs)
 
     def debug(self, message, *args, **kwargs):
         self.log.setLevel(logging.DEBUG)
         self.change_format('{} - {} - %(message)s'.format(
             self.get_time().to_datetime_string(),
             'DEBUG'))
-        return self.log.debug(message) 
+        return self.log.debug(message, *args, **kwargs) 
     

--- a/src/masonite/logging/listeners.py
+++ b/src/masonite/logging/listeners.py
@@ -13,4 +13,4 @@ class LoggerExceptionListener(BaseExceptionListener):
             exception.__class__.__name__, 
             file,
             line,
-        ))
+        ), exc_info=True)

--- a/src/masonite/logging/listeners.py
+++ b/src/masonite/logging/listeners.py
@@ -9,8 +9,9 @@ class LoggerExceptionListener(BaseExceptionListener):
         self.logger = logger
 
     def handle(self, exception, file, line):
-        self.logger.error("{} in {} on line {}".format(
+        self.logger.error("{} in {} on line {} \n {} \n".format(
             exception.__class__.__name__, 
             file,
-            line
+            line,
+            exception.__str__()
         ))

--- a/src/masonite/logging/listeners.py
+++ b/src/masonite/logging/listeners.py
@@ -9,9 +9,8 @@ class LoggerExceptionListener(BaseExceptionListener):
         self.logger = logger
 
     def handle(self, exception, file, line):
-        self.logger.error("{} in {} on line {} \n {} \n".format(
+        self.logger.error("{} in {} on line {} \n".format(
             exception.__class__.__name__, 
             file,
             line,
-            exception.__str__()
         ))

--- a/tests/local/test_single_channel.py
+++ b/tests/local/test_single_channel.py
@@ -15,3 +15,31 @@ class TestSingleChannel(unittest.TestCase):
     def fileExists(self, location):
         self.assertTrue(os.path.exists(location), "location '{}' does not exist".format(location))
         return self
+
+    def test_exc_info(self):
+        
+        def raise_link(self):
+            try:
+                raise Exception('this is a first exception')
+            except Exception as e:
+                raise e
+
+        def raise_link2(self):
+            try:
+                raise_link(self)
+            except Exception as e:
+                raise e
+
+        try:
+            raise_link2(self)
+        except Exception as e:
+            self.channel.error(e, exc_info=True)
+            self.checkTraceInfo()
+        
+    def checkTraceInfo(self):
+        fileContain = False
+        with open("storage/logs/single.log", 'r') as read_obj:
+            if "Traceback (most recent call last)" in read_obj:
+                fileContain = True
+        self.assertTrue(fileContain)
+        


### PR DESCRIPTION
There are some keyword arguments in `kwags` that can be set to display more log information。 but `args` and `kwags` are disabled in the log driver. 
I have added the test. 